### PR TITLE
Erc20

### DIFF
--- a/src/nicp_cdk/ic0/wasm.nim
+++ b/src/nicp_cdk/ic0/wasm.nim
@@ -1,29 +1,5 @@
 import std/macros
 
-
-# {.emit: """
-# #pragma once
-
-# // See: https://lld.llvm.org/WebAssembly.html#imports
-# #define WASM_SYMBOL_IMPORTED(module, name)                                     \
-#   __attribute__((import_module(module))) __attribute__((import_name(name)));
-
-# // See: https://lld.llvm.org/WebAssembly.html#exports
-# #define WASM_SYMBOL_EXPORTED(name)                                             \
-#   asm(name) __attribute__((visibility("default")));
-# """.}
-
-# proc WASM_SYMBOL_IMPORTED*(module: string, name: string) {.header:"wasm_symbol.h", importc.}
-# proc WASM_SYMBOL_EXPORTED*(name: string) {.header:"wasm_symbol.h", importc.}
-
-# proc WASM_SYMBOL_IMPORTED*(module: string, name: string) = 
-#   {.emit:"""
-# // See: https://lld.llvm.org/WebAssembly.html#imports
-# #define WASM_SYMBOL_IMPORTED(module, name)                                     \
-#   __attribute__((import_module(module))) __attribute__((import_name(name)));
-# """.}
-
-
 # 引用
 # https://github.com/yglukhov/wasmrt/blob/master/wasmrt.nim#L4-L10
 
@@ -56,6 +32,7 @@ macro update*(p: untyped): untyped =
       name & "\"))) $# $#$#"
   result.addPragma(newColonExpr(ident"codegenDecl", newLit(codegenPragma)))
   result.addPragma(ident"exportc")
+
 
 {.emit: """
 #include <stddef.h>

--- a/src/nicp_cdk/ic_types/candid.nim
+++ b/src/nicp_cdk/ic_types/candid.nim
@@ -1,8 +1,14 @@
 import std/endians
+import std/sequtils
+import std/strutils
 import ../algorithm/leb128
 import ./consts
 import ./ic_principal
 import ./ic_text
+
+
+proc toString*(data: seq[byte]): string =
+  return data.mapIt(it.toHex()).join("")
 
 
 #---- Candid 型タグの定義 ----

--- a/src/nicp_cdk/ic_types/ic_principal.nim
+++ b/src/nicp_cdk/ic_types/ic_principal.nim
@@ -103,7 +103,6 @@ proc serializeCandid*(value: Principal): seq[byte] =
   buf.add byte(1); buf.add tagPrincipal
   # 3. 値シーケンス: IDフォーム(1) + バイト列長(ULEB128) + 生バイト列
   buf.add byte(1)                                      # IDフォーム識別子 :contentReference[oaicite:4]{index=4}
-  echo "encodeULEB128(uint(value.bytes.len)): ", encodeULEB128(uint(value.bytes.len))
   buf.add encodeULEB128(uint(value.bytes.len))        # ULEB128で長さを符号無しエンコード :contentReference[oaicite:5]{index=5}
   for b in value.bytes:
     buf.add b                                          # 生バイト列をそのまま追加

--- a/src/nicp_cdk/request.nim
+++ b/src/nicp_cdk/request.nim
@@ -1,4 +1,5 @@
 import ./ic_types/candid
+import ./ic_types/ic_principal
 import ./ic0/ic0
 
 
@@ -46,3 +47,10 @@ proc getStr*(self:Request, index:int): string =
   ## Get the argument at the specified index as a string
   assert self.values[index].kind == ctText
   return self.values[index].textVal
+
+
+# 指定されたインデックスの引数を Principal として取得する
+proc getPrincipal*(self:Request, index:int): Principal =
+  ## Get the argument at the specified index as a principal
+  assert self.values[index].kind == ctPrincipal
+  return self.values[index].principalVal


### PR DESCRIPTION
Title: Refactor WASM Module and Update Principal Handling in Candid Serialization

Detailed Description:
- In `src/nicp_cdk/ic0/wasm.nim`, removed legacy commented-out macros for WASM symbol import/export to clean up and streamline the codebase. Retained only the essential emitted code for including `<stddef.h>`.
- In `src/nicp_cdk/ic_types/candid.nim`:
  - Added a new helper procedure `toString*` that converts a sequence of bytes into a hexadecimal string using `std/sequtils` and `std/strutils`.
  - Modified the `readPrincipal*` procedure to improve principal deserialization:
    - After decoding the length using ULEB128, the final byte of the length segment is used to determine the actual number of principal bytes.
    - Ensured the correct slice of bytes is extracted and the offset is updated accordingly.
- In `src/nicp_cdk/request.nim`:
  - Imported the `ic_principal` module to support principal-related operations.
  - Added a new procedure `getPrincipal*` to retrieve a principal argument from a request by asserting its type.

These changes enhance readability, correctness, and maintainability of the principal handling and the overall serialization process.