### PR TITLE
feat: ECDSA公開鍵の取得と保存をリファクタリング

### DIFF
--- a/examples/async_t_ecdsa/async_t_ecdsa.did
+++ b/examples/async_t_ecdsa/async_t_ecdsa.did
@@ -1,3 +1,4 @@
 service : {
-  "getPublicKey" : () -> (text);
+  "getNewPublicKey" : () -> (text);
+  "getPublicKey" : () -> (text) query;
 };

--- a/examples/async_t_ecdsa/src/async_t_ecdsa_backend/controller.nim
+++ b/examples/async_t_ecdsa/src/async_t_ecdsa_backend/controller.nim
@@ -1,0 +1,44 @@
+import std/asyncdispatch
+import std/options
+import std/sequtils
+import std/strutils
+import std/tables
+import ../../../../src/nicp_cdk
+import ../../../../src/nicp_cdk/canisters/async_management_canister
+
+
+var keys = initTable[Principal, string]()
+
+proc getNewPublicKey*() {.async.} =
+  let caller = Msg.caller()
+
+  if keys.hasKey(caller):
+    echo "=== getPublicKeyAsync: already has key ==="
+    reply(keys[caller])
+    return
+
+  echo "=== getPublicKeyAsync: no key ==="
+  let arg = EcdsaPublicKeyArgs(
+    canister_id: Principal.fromText("be2us-64aaa-aaaaa-qaabq-cai").some(),
+    derivation_path: @[caller.bytes],
+    key_id: EcdsaKeyId(
+      curve: EcdsaCurve.secp256k1,
+      name: "dfx_test_key"
+    )
+  )
+
+  try:
+    let result = await ManagementCanister.publicKey(arg)
+    let publicKey = "0x" & result.public_key.map(proc(x: uint8): string = x.toHex()).join("")
+    keys[caller] = publicKey
+    reply(publicKey)
+  except ValueError as e:
+    reject("Failed to get public key: " & e.msg)
+
+
+proc getPublicKey*() =
+  let caller = Msg.caller()
+  if keys.hasKey(caller):
+    reply(keys[caller])
+  else:
+    reject("No key found")

--- a/examples/async_t_ecdsa/src/async_t_ecdsa_backend/main.nim
+++ b/examples/async_t_ecdsa/src/async_t_ecdsa_backend/main.nim
@@ -1,31 +1,8 @@
-import std/asyncdispatch
-import std/options
-import std/sequtils
-import std/strutils
-import std/tables
 import ../../../../src/nicp_cdk
-import ../../../../src/nicp_cdk/canisters/async_management_canister
-
-proc getPublicKeyAsync() {.async.} =
-  let caller = Msg.caller()
-  let arg = EcdsaPublicKeyArgs(
-    canister_id: Principal.fromText("be2us-64aaa-aaaaa-qaabq-cai").some(),
-    derivation_path: @[caller.bytes],
-    key_id: EcdsaKeyId(
-      curve: EcdsaCurve.secp256k1,
-      name: "dfx_test_key"
-    )
-  )
-
-  try:
-    let result = await ManagementCanister.publicKey(arg)
-    let publicKey = "0x" & result.public_key.map(proc(x: uint8): string = x.toHex()).join("")
-    reply(publicKey)
-  except ValueError as e:
-    reject("Failed to get public key: " & e.msg)
+import ./controller
 
 # ----------------------------------------------------------------------------
 # IC に公開する update エントリポイント（返値なし）
 # ----------------------------------------------------------------------------
-
-proc getPublicKey*() {.update.} = discard getPublicKeyAsync()
+proc getNewPublicKey*() {.update.} = discard controller.getNewPublicKey()
+proc getPublicKey*() {.query.} = controller.getPublicKey()


### PR DESCRIPTION
- `examples/async_t_ecdsa/src/async_t_ecdsa_backend/controller.nim` を新規作成し、ECDSA公開鍵の取得ロジックと保存機能を分離。
- `examples/async_t_ecdsa/src/async_t_ecdsa_backend/main.nim` から非同期ロジックを削除し、`controller.nim` の関数を呼び出すように変更。
- `async_t_ecdsa.did` にて、既存の `getPublicKey` を `getNewPublicKey` (updateメソッド) に変更し、初回取得または更新を行う。
- `async_t_ecdsa.did` に、保存されている公開鍵を即座に取得するための `getPublicKey` (queryメソッド) を追加。
- `controller.nim` に `keys` テーブルを導入し、Principalごとに公開鍵を保存する機能を追加。
- `getNewPublicKey` は、呼び出し元が既に鍵を所有している場合は既存の鍵を返し、そうでない場合は新しい鍵を取得して保存する。
- `getPublicKey` は、保存されている鍵を返す。鍵が見つからない場合はエラーを返す。