### PR TITLE
feat(t-ecdsa): Internet Identity認証をフロントエンドに実装

### DIFF
--- a/examples/t_ecdsa/src/t_ecdsa_frontend/src/hooks/icp.ts
+++ b/examples/t_ecdsa/src/t_ecdsa_frontend/src/hooks/icp.ts
@@ -2,12 +2,95 @@ import {
   createActor as createTEcdsaBackendActor,
 } from "../../../declarations/t_ecdsa_backend";
 import {
+  canisterId as INTERNET_IDENTITY_CANISTER_ID
+} from "../../../declarations/internet_identity"
+import {
   type Address,
   getAddress,
 } from 'viem';
+import { AuthClient } from '@dfinity/auth-client';
 
+// Internet Identity provider URL
+const network = process.env.DFX_NETWORK;
+const identityProvider =
+  network === 'ic'
+    ? 'https://identity.ic0.app' // Mainnet
+    : `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`; // Local
+
+export const login = async (): Promise<boolean> => {
+  try {
+    const authClient = await AuthClient.create();
+    
+    return new Promise((resolve) => {
+      authClient.login({
+        identityProvider,
+        onSuccess: () => {
+          console.log('Login successful');
+          resolve(true);
+        },
+        onError: (error) => {
+          console.error('Login failed:', error);
+          resolve(false);
+        }
+      });
+    });
+  } catch (error) {
+    console.error('Failed to create auth client:', error);
+    return false;
+  }
+};
+
+// Logout function
+export const logout = async (): Promise<void> => {
+  try {
+    const authClient = await AuthClient.create();
+    await authClient.logout();
+    console.log('Logout successful');
+  } catch (error) {
+    console.error('Logout failed:', error);
+  }
+};
+
+// Check if user is authenticated
+export const isAuthenticated = async (): Promise<boolean> => {
+  try {
+    const authClient = await AuthClient.create();
+    return await authClient.isAuthenticated();
+  } catch (error) {
+    console.error('Failed to check authentication status:', error);
+    return false;
+  }
+};
+
+// Get current user's principal
+export const getCurrentPrincipal = async (): Promise<string | null> => {
+  try {
+    const authClient = await AuthClient.create();
+    if (await authClient.isAuthenticated()) {
+      const identity = authClient.getIdentity();
+      return identity.getPrincipal().toString();
+    }
+    return null;
+  } catch (error) {
+    console.error('Failed to get current principal:', error);
+    return null;
+  }
+};
+
+// Create authenticated actor
+export const createAuthenticatedActor = async () => {
+  const authClient = await AuthClient.create();
+  const identity = authClient.getIdentity();
+  
+  return createTEcdsaBackendActor(process.env.CANISTER_ID_T_ECDSA_BACKEND, {
+    agentOptions: {
+      identity
+    }
+  });
+};
+
+// Default unauthenticated actor for backwards compatibility
 const tEcdsaBackendActor = createTEcdsaBackendActor(process.env.CANISTER_ID_T_ECDSA_BACKEND);
-
 
 export const getEvmAddress = async (): Promise<Address> => {
   try{

--- a/examples/t_ecdsa/src/t_ecdsa_frontend/src/index.tsx
+++ b/examples/t_ecdsa/src/t_ecdsa_frontend/src/index.tsx
@@ -2,7 +2,7 @@ import { hydrate, prerender as ssr } from 'preact-iso';
 import { useState, useEffect } from 'preact/hooks';
 import { Address, createPublicClient, http } from 'viem';
 import { mainnet } from 'viem/chains';
-import { getEvmAddress, signMessage } from './hooks/icp';
+import { getEvmAddress, signMessage, login, logout, isAuthenticated, getCurrentPrincipal } from './hooks/icp';
 
 const publicClient = createPublicClient({
 	chain: mainnet,
@@ -10,6 +10,8 @@ const publicClient = createPublicClient({
 });
 
 export function App() {
+	const [isLogin, setIsLogin] = useState<boolean>(false);
+	const [principal, setPrincipal] = useState<string | null>(null);
 	const [accountAddress, setAccountAddress] = useState<Address | null>(null);
 	const [message, setMessage] = useState<string | null>("hello world");
 	const [signature, setSignature] = useState<string | null>(null);
@@ -17,10 +19,47 @@ export function App() {
 
 	useEffect(() => {
 		(async()=>{
-			const address = await getEvmAddress();
-			setAccountAddress(address);
+			// Check authentication status on load
+			const authenticated = await isAuthenticated();
+			setIsLogin(authenticated);
+			
+			if (authenticated) {
+				// Get principal and address only if authenticated
+				const principalId = await getCurrentPrincipal();
+				setPrincipal(principalId);
+				
+				const address = await getEvmAddress();
+				setAccountAddress(address);
+			} else {
+				// Clear data if not authenticated
+				setPrincipal(null);
+				setAccountAddress(null);
+			}
 		})()
 	}, []);
+
+	const handleLogin = async () => {
+		if (isLogin) {
+			// Logout
+			await logout();
+			setIsLogin(false);
+			setPrincipal(null);
+			setAccountAddress(null);
+		} else {
+			// Login
+			const success = await login();
+			if (success) {
+				setIsLogin(true);
+				
+				// Get principal and address after successful login
+				const principalId = await getCurrentPrincipal();
+				setPrincipal(principalId);
+				
+				const address = await getEvmAddress();
+				setAccountAddress(address);
+			}
+		}
+	};
 
 	const handleSign = async () => {
 		const signature = await signMessage({ message });
@@ -37,7 +76,16 @@ export function App() {
 		<main>
 			<article>
 				<h2>T-ECDSA</h2>
-				<p>Account Address: {accountAddress}</p>
+				<button onClick={handleLogin}>
+					{isLogin ? 'Logout' : 'Login with Internet Identity'}
+				</button>
+				<p>Status: {isLogin ? 'Authenticated' : 'Not authenticated'}</p>
+				{isLogin && (
+					<>
+						<p>Principal: {principal}</p>
+						<p>Account Address: {accountAddress}</p>
+					</>
+				)}
 				<hr />
 				<input
 						type="text"


### PR DESCRIPTION
- `icp.ts`にInternet Identity認証のためのログイン、ログアウト、認証状態チェック、プリンシパル取得、および認証済みアクター作成の機能を追加しました。
- `index.tsx`でInternet Identity認証フローを統合し、ログイン状態に基づいてUIを更新するように変更しました。
- ユーザーはInternet Identityを介してログイン/ログアウトでき、認証後にプリンシパルとEVMアドレスを表示します。