### PR TITLE
テストとECDSA関連のリファクタ・デバッグ出力削除

### DIFF
--- a/src/nicp_cdk/algorithm/ecdsa.nim
+++ b/src/nicp_cdk/algorithm/ecdsa.nim
@@ -12,7 +12,7 @@ type
   EcdsaError* = object of ValueError
 
 
-proc keccak256Hash*(message: string): seq[uint8] =
+func keccak256Hash*(message: string): seq[uint8] =
   ## Calculate Keccak-256 hash of message
   var keccakCtx: keccak256
   keccakCtx.init()

--- a/src/nicp_cdk/algorithm/ethereum.nim
+++ b/src/nicp_cdk/algorithm/ethereum.nim
@@ -50,7 +50,7 @@ proc decompressPublicKey*(compressedKey: seq[uint8]): seq[uint8] =
     raise newException(EthereumConversionError, "secp256k1 decompression failed")
 
 
-proc keccak256Hash*(data: string): seq[uint8] =
+func keccak256Hash*(data: string): seq[uint8] =
   ## Hash string data using Keccak-256 with EIP-191 format
   ## This follows the Ethereum personal_sign standard: "\x19Ethereum Signed Message:\n" + length + message
   

--- a/tests/management_canister/test_ecdsa.nim
+++ b/tests/management_canister/test_ecdsa.nim
@@ -13,17 +13,12 @@ const
   DFX_PATH = "/root/.local/share/dfx/bin/dfx"
   T_ECDSA_DIR = "/application/examples/t_ecdsa"
 
-proc logDebug(msg: string) =
-  stdout.write("[DEBUG] " & msg & "\n")
 
 proc previewString(s: string): string =
   if s.len <= 50:
     s
   else:
     s.substr(0, 50) & "..."
-
-proc logResponse(source: string, response: string) =
-  stdout.write("[RESPONSE] " & source & ": " & response & "\n")
 
 # 共通のヘルパープロシージャ
 proc callCanisterFunction(functionName: string, args: string = ""): string =
@@ -34,18 +29,14 @@ proc callCanisterFunction(functionName: string, args: string = ""): string =
       DFX_PATH & " canister call t_ecdsa_backend " & functionName
     else:
       DFX_PATH & " canister call t_ecdsa_backend " & functionName & " '(" & args & ")' "
-    logDebug("Calling canister function: " & command.replace("\n", " "))
     let execResult = execProcess(command)
-    logDebug(fmt"callCanisterFunction result for {functionName} len={execResult.len} preview={previewString(execResult)}")
-    logResponse(functionName, execResult)
     return execResult
   finally:
     setCurrentDir(originalDir)
 
 proc runCommand(command: string) =
   let (output, code) = execCmdEx(command)
-  if code != 0:
-    logDebug("command failed output: " & output)
+  # echo output
   check code == 0
 
 proc ensureFrontendBuilt() =
@@ -53,10 +44,8 @@ proc ensureFrontendBuilt() =
   try:
     setCurrentDir(T_ECDSA_DIR)
 
-    logDebug("Installing frontend dependencies with pnpm at workspace root")
     runCommand("pnpm install --frozen-lockfile")
 
-    logDebug("Generating backend declarations with dfx")
     runCommand(DFX_PATH & " canister create --all")
     runCommand(DFX_PATH & " deploy t_ecdsa_backend")
     runCommand(DFX_PATH & " generate t_ecdsa_backend")
@@ -70,13 +59,11 @@ proc ensureFrontendBuilt() =
 
 suite "Deploy Tests":
   test "Deploy ECDSA canister":
-    logDebug("Deploy ECDSA canister: start")
     let originalDir = getCurrentDir()
     try:
       setCurrentDir(T_ECDSA_DIR)
       ensureFrontendBuilt()
       let deployResult = execProcess(DFX_PATH & " deploy -y")
-      logDebug(fmt"deploy result len={deployResult.len}")
       # deployが成功した場合を確認
       check deployResult.contains("Deployed") or deployResult.contains("Creating") or 
             deployResult.contains("Installing") or deployResult.contains("t_ecdsa_backend")
@@ -88,10 +75,8 @@ suite "Deploy Tests":
 
 suite "ECDSA Management Canister Tests":
   test "Test getPublicKey query function":
-    logDebug("Test getPublicKey query function: start")
     sleep(1000)  # キャニスターの完全な準備を待つ
     let callResult = callCanisterFunction("getPublicKey")
-    logDebug(fmt"getPublicKey result len={callResult.len} preview={previewString(callResult)}")
     # クエリ関数が正常に実行されることを確認
     # キーが存在する場合は16進文字列、存在しない場合は適切なエラーメッセージが返される
     check callResult.contains("\"") or 
@@ -100,9 +85,7 @@ suite "ECDSA Management Canister Tests":
           callResult.contains("reject")
 
   test "Test getNewPublicKey update function":
-    logDebug("Test getNewPublicKey update function: start")
     let callResult = callCanisterFunction("getNewPublicKey")
-    logDebug(fmt"getNewPublicKey result len={callResult.len} preview={previewString(callResult)}")
     # 新しい公開鍵が生成されることを確認
     # 実際の出力は16進文字列（0xプレフィックスなし）または適切なエラーメッセージ
     check callResult.contains("\"") or 
@@ -112,17 +95,14 @@ suite "ECDSA Management Canister Tests":
           callResult.len > 10  # 有効な16進文字列が含まれる
 
   test "Test getPublicKey after getNewPublicKey":
-    logDebug("Test getPublicKey after getNewPublicKey: start")
     # まず新しいキーを生成
     discard callCanisterFunction("getNewPublicKey")
     
     # 少し待ってからクエリ
     let queryResult = callCanisterFunction("getPublicKey")
-    logDebug(fmt"after getNewPublicKey query result len={queryResult.len} preview={previewString(queryResult)}")
     
     # Step 3: EVMアドレスをテスト
     let evmResult = callCanisterFunction("getEvmAddress")
-    logDebug(fmt"EVM address result len={evmResult.len} preview={previewString(evmResult)}")
     
     # 新しいキーが生成された場合、クエリでも同じキーが取得できることを確認
     check queryResult.contains("\"") and queryResult.len > 10
@@ -132,7 +112,6 @@ suite "ECDSA Management Canister Tests":
 
 suite "ECDSA Signature and Verification Tests":
   test "Test signWithEcdsa basic functionality":
-    logDebug("Test signWithEcdsa basic functionality: start")
     sleep(1000)  # キャニスターの完全な準備を待つ
     # まず公開鍵を生成して準備
     discard callCanisterFunction("getNewPublicKey")
@@ -140,7 +119,6 @@ suite "ECDSA Signature and Verification Tests":
     # メッセージに署名
     let testMessage = "\"Hello, ICP ECDSA!\""
     let signResult = callCanisterFunction("signWithEcdsa", testMessage)
-    logDebug(fmt"signWithEcdsa result len={signResult.len} preview={previewString(signResult)}")
     
     # 署名が正常に生成されることを確認
     check signResult.contains("\"") and signResult.len > 10
@@ -148,7 +126,6 @@ suite "ECDSA Signature and Verification Tests":
     check not signResult.contains("reject") and not signResult.contains("Failed")
 
   test "Test verifyWithEcdsa with valid signature":
-    logDebug("Test verifyWithEcdsa with valid signature: start")
     
     # Step 1: 公開鍵を取得
     let publicKeyResult = callCanisterFunction("getNewPublicKey")
@@ -156,7 +133,6 @@ suite "ECDSA Signature and Verification Tests":
     # Step 2: メッセージに署名
     let testMessage = "\"Test message for verification\""
     let signatureResult = callCanisterFunction("signWithEcdsa", testMessage)
-    logDebug(fmt"signature result len={signatureResult.len} preview={previewString(signatureResult)}")
     
     # Step 3: 署名を検証
     
@@ -173,13 +149,11 @@ suite "ECDSA Signature and Verification Tests":
     let verifyArgs = fmt"""record {{ message = {testMessage}; signature = "{cleanSignature}"; publicKey = "{publicKey}"; }}"""
     
     let verifyResult = callCanisterFunction("verifyWithEcdsa", verifyArgs)
-    logDebug(fmt"verifyResult len={verifyResult.len} preview={previewString(verifyResult)}")
     
     # 検証結果がtrueであることを確認
     check verifyResult.contains("true") or verifyResult.contains("(true)")
 
   test "Test verifyWithEcdsa with invalid signature":
-    logDebug("Test verifyWithEcdsa with invalid signature: start")
     
     # Step 1: 公開鍵を取得
     let publicKeyResult = callCanisterFunction("getNewPublicKey")
@@ -192,14 +166,12 @@ suite "ECDSA Signature and Verification Tests":
     let verifyArgs = fmt"""record {{ message = "{testMessage}"; signature = "{invalidSignature}"; publicKey = "{publicKey}"; }}"""
     
     let verifyResult = callCanisterFunction("verifyWithEcdsa", verifyArgs)
-    logDebug(fmt"invalid verify result len={verifyResult.len} preview={previewString(verifyResult)}")
     
     # 不正な署名は検証に失敗するべき
     check verifyResult.contains("false") or verifyResult.contains("(false)") or
           verifyResult.contains("reject") or verifyResult.contains("Failed")
 
   test "Test signWithEcdsa with different messages":
-    logDebug("Test signWithEcdsa with different messages: start")
     
     # 複数の異なるメッセージで署名をテスト
     let messages = @[
@@ -209,23 +181,18 @@ suite "ECDSA Signature and Verification Tests":
     ]
     
     for i, message in messages:
-      logDebug(fmt"signWithEcdsa different message {i}: {message}")
       let signResult = callCanisterFunction("signWithEcdsa", message)
-      logDebug(fmt"signWithEcdsa message {i} result len={signResult.len} preview={previewString(signResult)}")
       
       # 各メッセージで署名が生成されることを確認
       check signResult.contains("\"") and signResult.len > 10
 
   test "Test getNewPublicKey function multiple times":
-    logDebug("Test getNewPublicKey function multiple times: start")
     
     # 最初の呼び出し
     let firstResult = callCanisterFunction("getNewPublicKey")
     
     # 2回目の呼び出し（キャッシュされた結果が返される）
     let secondResult = callCanisterFunction("getNewPublicKey")
-    logDebug(fmt"first getNewPublicKey len={firstResult.len} preview={previewString(firstResult)}")
-    logDebug(fmt"second getNewPublicKey len={secondResult.len} preview={previewString(secondResult)}")
     
     # 両方とも何らかの結果が返されることを確認
     check firstResult.len > 0
@@ -234,22 +201,18 @@ suite "ECDSA Signature and Verification Tests":
 
 suite "EVM Address Tests":
   test "Test getEvmAddress without public key":
-    logDebug("Test getEvmAddress without public key: start")
     sleep(1000)  # キャニスターの完全な準備を待つ
     let evmResult = callCanisterFunction("getEvmAddress")
-    logDebug(fmt"EVM address without key len={evmResult.len} preview={previewString(evmResult)}")
     # データベースにキーが既に存在する場合はアドレスが返され、存在しない場合は空文字列
     check evmResult.contains("0x") or evmResult.contains("\"\"") or evmResult.contains("reject")
 
   test "Test getEvmAddress after generating public key":
-    logDebug("Test getEvmAddress after generating public key: start")
     
     # まず公開鍵を生成
     discard callCanisterFunction("getNewPublicKey")
     
     # EVMアドレスを取得
     let evmResult = callCanisterFunction("getEvmAddress")
-    logDebug(fmt"EVM address after key len={evmResult.len} preview={previewString(evmResult)}")
     
     # 公開鍵が正常に生成された場合、EVMアドレスも取得できるべき
     check evmResult.contains("0x") and evmResult.len > 10
@@ -257,24 +220,19 @@ suite "EVM Address Tests":
 
 suite "ECDSA Integration Tests":
   test "Test full ECDSA workflow":
-    logDebug("Test full ECDSA workflow: start")
     sleep(1000)  # キャニスターの完全な準備を待つ
     
     # Step 1: 新しい公開鍵を生成
     let newKeyResult = callCanisterFunction("getNewPublicKey")
-    logDebug(fmt"workflow newKeyResult len={newKeyResult.len} preview={previewString(newKeyResult)}")
     
     # Step 2: 生成された公開鍵をクエリ
     let queryResult = callCanisterFunction("getPublicKey")
-    logDebug(fmt"workflow queryResult len={queryResult.len} preview={previewString(queryResult)}")
     
     # Step 3: EVMアドレスを取得
     let evmResult = callCanisterFunction("getEvmAddress")
-    logDebug(fmt"workflow evmResult len={evmResult.len} preview={previewString(evmResult)}")
     
     # Step 4: 再度公開鍵をクエリして一貫性を確認
     let reQueryResult = callCanisterFunction("getPublicKey")
-    logDebug(fmt"workflow reQueryResult len={reQueryResult.len} preview={previewString(reQueryResult)}")
     
     # 各ステップが完了することを確認（エラーでも良い）
     check newKeyResult.len > 0


### PR DESCRIPTION
[1 tool called]

feat: テストとECDSA関連のリファクタ・デバッグ出力削除

- examples/type_test: 自キャニスター参照の生成で Principal を明示し、`IcFunc.new` の引数を整理
- tests/test_encode_response: ビルドコマンド修正、関数参照出力を `repr` から `methodName` に変更、期待値チェックを追加
- src/nicp_cdk/algorithm/{ecdsa,ethereum}.nim: `keccak256Hash` を `proc` から `func` に変更（副作用のないハッシュ関数として明示）
- tests/management_canister/test_ecdsa.nim: デバッグ用ログ関数と多数のログ出力を削除し、テスト実行の冗長なデバッグ情報を簡素化。`runCommand` の失敗判定を明確化

理由: テスト出力のノイズを減らし、ハッシュ関数のシグネチャを副作用なしに明示することでコードの可読性と一貫性を向上。