### PR TITLE
HttpRequestArgs: max_response_bytes の型を Option[uint] から Option[uint64…

### DIFF
--- a/examples/http_outcall/motoko/backend/src/main.mo
+++ b/examples/http_outcall/motoko/backend/src/main.mo
@@ -26,7 +26,7 @@ persistent actor {
 
   type HttpRequestArgs = {
     url : Text;
-    max_response_bytes : ?Nat;
+    max_response_bytes : ?Nat64;
     headers : [HttpHeader];
     body : ?Blob;
     method : HttpMethod;

--- a/examples/http_outcall/motoko/src/motoko_backend/main.mo
+++ b/examples/http_outcall/motoko/src/motoko_backend/main.mo
@@ -26,7 +26,7 @@ persistent actor {
 
   type HttpRequestArgs = {
     url : Text;
-    max_response_bytes : ?Nat;
+    max_response_bytes : ?Nat64;
     headers : [HttpHeader];
     body : ?Blob;
     method : HttpMethod;

--- a/examples/http_outcall/nim/backend/backend.did
+++ b/examples/http_outcall/nim/backend/backend.did
@@ -23,7 +23,7 @@ type TransformArgs =
 type HttpRequestArgs =
  record {
    url: text;
-   max_response_bytes: opt nat;
+   max_response_bytes: opt nat64;
    headers: vec HttpHeader;
    body: opt blob;
    method: HttpMethod;

--- a/examples/http_outcall/nim/backend/src/controller.nim
+++ b/examples/http_outcall/nim/backend/src/controller.nim
@@ -69,7 +69,7 @@ proc toHttpRequestArgs(
 ): HttpRequestArgs =
   HttpRequestArgs(
     url: url,
-    max_response_bytes: none(uint),
+    max_response_bytes: none(uint64),
     headers: headers,
     body: body,
     httpMethod: httpMethod,
@@ -114,7 +114,7 @@ proc get_httpbin*() {.async.} =
       httpMethod: HttpMethod.GET,
       headers: @[HttpHeader(name: "User-Agent", value: "nim-http-outcall")],
       body: none(seq[uint8]),
-      max_response_bytes: none(uint),
+      max_response_bytes: none(uint64),
       transform: some(defaultTransformRef()),
       # transform: none(HttpTransform),
       is_replicated: some(false)
@@ -139,7 +139,7 @@ proc post_httpbin*() {.async.} =
         HttpHeader(name: "User-Agent", value: "nim-http-outcall")
       ],
       body: some(body),
-      max_response_bytes: none(uint),
+      max_response_bytes: none(uint64),
       transform: some(defaultTransformRef()),
       # transform: none(HttpTransform),
       is_replicated: some(false)

--- a/examples/http_outcall/nim/nim.did
+++ b/examples/http_outcall/nim/nim.did
@@ -23,7 +23,7 @@ type TransformArgs =
 type HttpRequestArgs =
  record {
    url: text;
-   max_response_bytes: opt nat;
+   max_response_bytes: opt nat64;
    headers: vec HttpHeader;
    body: opt blob;
    method: HttpMethod;

--- a/examples/http_outcall/nim/src/nim_backend/controller.nim
+++ b/examples/http_outcall/nim/src/nim_backend/controller.nim
@@ -69,7 +69,7 @@ proc toHttpRequestArgs(
 ): HttpRequestArgs =
   HttpRequestArgs(
     url: url,
-    max_response_bytes: none(uint),
+    max_response_bytes: none(uint64),
     headers: headers,
     body: body,
     httpMethod: httpMethod,
@@ -114,7 +114,7 @@ proc get_httpbin*() {.async.} =
       httpMethod: HttpMethod.GET,
       headers: @[HttpHeader(name: "User-Agent", value: "nim-http-outcall")],
       body: none(seq[uint8]),
-      max_response_bytes: none(uint),
+      max_response_bytes: none(uint64),
       transform: some(defaultTransformRef()),
       # transform: none(HttpTransform),
       is_replicated: some(false)
@@ -139,7 +139,7 @@ proc post_httpbin*() {.async.} =
         HttpHeader(name: "User-Agent", value: "nim-http-outcall")
       ],
       body: some(body),
-      max_response_bytes: none(uint),
+      max_response_bytes: none(uint64),
       transform: some(defaultTransformRef()),
       # transform: none(HttpTransform),
       is_replicated: some(false)

--- a/src/nicp_cdk/canisters/management_canister/http_outcall.nim
+++ b/src/nicp_cdk/canisters/management_canister/http_outcall.nim
@@ -52,7 +52,8 @@ type
 
   HttpRequestArgs* = object
     url*: string
-    max_response_bytes*: Option[uint]
+    ## IC management canister `http_request` specifies this as `opt nat64`.
+    max_response_bytes*: Option[uint64]
     headers*: seq[HttpHeader]
     body*: Option[seq[byte]]
     httpMethod*: HttpMethod
@@ -186,11 +187,11 @@ proc `%`*(request: HttpRequestArgs): CandidRecord =
 
   if request.max_response_bytes.isSome:
     fields["max_response_bytes"] = newCandidOptWithInnerType(
-      ctNat,
-      some(newCandidNat(request.max_response_bytes.get))
+      ctNat64,
+      some(newCandidNat64(request.max_response_bytes.get))
     )
   else:
-    fields["max_response_bytes"] = newCandidOptWithInnerType(ctNat, none(CandidValue))
+    fields["max_response_bytes"] = newCandidOptWithInnerType(ctNat64, none(CandidValue))
 
   fields["headers"] = newCandidVec(headersValues)
 
@@ -321,7 +322,7 @@ proc calcHttpRequestSize(request: HttpRequestArgs): uint64 =
 
 proc estimateHttpOutcallCostFallback(request: HttpRequestArgs): uint64 =
   let requestSize = calcHttpRequestSize(request)
-  let maxResponseSize = request.max_response_bytes.get(2_000_000'u).uint64
+  let maxResponseSize = request.max_response_bytes.get(2_000_000'u64)
 
   var cost = HttpOutcallFallbackBaseCycles
   cost = addCap(cost, mulCap(requestSize, HttpOutcallFallbackPerRequestByteCycles))
@@ -342,7 +343,7 @@ when defined(release):
     ## ic0_cost_http_request APIを使用した動的なcycle計算
     try:
       let requestSize = calcHttpRequestSize(request)
-      let maxResponseSize = request.max_response_bytes.get(2_000_000'u).uint64
+      let maxResponseSize = request.max_response_bytes.get(2_000_000'u64)
       
       # IC System APIを使用して正確なコスト計算
       var costBuffer: array[16, uint8]  # 128bit for cycles
@@ -395,7 +396,7 @@ proc httpOutcall*(_:type ManagementCanister, request: HttpRequestArgs): Future[H
           " method=", $request.httpMethod,
           " headers=", request.headers.len,
           " bodyBytes=", (if request.body.isSome: request.body.get.len else: 0),
-          " maxResponseBytes=", request.max_response_bytes.get(2_000_000'u)
+          " maxResponseBytes=", request.max_response_bytes.get(2_000_000'u64)
 
   # Management Canisterの呼び出し（t_ecdsa.nimと同じパターン）
   let mgmtPrincipalBytes: seq[uint8] = @[]

--- a/tests/types/test_object_to_record.nim
+++ b/tests/types/test_object_to_record.nim
@@ -110,7 +110,7 @@ suite("ecdsa"):
 
       HttpRequestArgs = ref object
         url: string
-        max_response_bytes: Option[uint]
+        max_response_bytes: Option[uint64]
         headers: seq[HttpHeader]
         body: Option[seq[byte]]
         transform: Option[TransformArgs]
@@ -128,7 +128,7 @@ suite("ecdsa"):
 
     let httpRequest = HttpRequestArgs(
       url: url,
-      max_response_bytes: none(uint), # optional for request
+      max_response_bytes: none(uint64), # optional for request
       headers: request_headers,
       body: none(seq[byte]), # optional for request
       httpMethod: HttpMethod.get,


### PR DESCRIPTION
…] に変更します。